### PR TITLE
Fix: Add missing pandas dependency and correct import paths

### DIFF
--- a/bmab/nodes/cnloader.py
+++ b/bmab/nodes/cnloader.py
@@ -147,7 +147,7 @@ class BMABControlNetOpenpose(BMABControlNet):
 		input_dir = folder_paths.get_input_directory()
 		files = utils.get_file_list(input_dir, input_dir)
 		try:
-			from comfyui_controlnet_aux.node_wrappers.openpose import OpenPose_Preprocessor
+			from custom_nodes.comfyui_controlnet_aux.node_wrappers.openpose import OpenPose_Preprocessor
 			return {
 				'required': {
 					'bind': ('BMAB bind',),
@@ -234,7 +234,7 @@ class BMABControlNetIPAdapter(BMABControlNet):
 		files = utils.get_file_list(input_dir, input_dir)
 
 		try:
-			from ComfyUI_IPAdapter_plus import IPAdapterPlus
+			from custom_nodes.ComfyUI_IPAdapter_plus import IPAdapterPlus
 			return {
 				'required': {
 					'bind': ('BMAB bind',),

--- a/bmab/nodes/detailers.py
+++ b/bmab/nodes/detailers.py
@@ -515,8 +515,8 @@ class BMABOpenposeHandDetailer(BMABDetailer):
 	@classmethod
 	def INPUT_TYPES(s):
 		try:
-			from comfyui_controlnet_aux.node_wrappers.dwpose import DWPose_Preprocessor
-			from comfyui_controlnet_aux.node_wrappers.openpose import OpenPose_Preprocessor
+			from custom_nodes.comfyui_controlnet_aux.node_wrappers.dwpose import DWPose_Preprocessor
+			from custom_nodes.comfyui_controlnet_aux.node_wrappers.openpose import OpenPose_Preprocessor
 
 			return {
 				'required': {

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ pillow
 pillow_avif_plugin
 blendmodes
 diffusers
+pandas


### PR DESCRIPTION
Hello!

I'm not sure if this is the intended way to fix these issues, but I can confirm that these changes resolve the loading problems on the latest version of ComfyUI. This PR addresses two bugs I found.

1. Added pandas to requirements.txt
Problem: After a fresh installation, the custom node fails to load with an Import Failed error because the pandas library is used but not listed as a dependency.

Solution: This change adds pandas to requirements.txt to ensure it is installed automatically with the other requirements.

2. Fixed Incorrect Absolute Import Paths
Problem: The nodes attempt to import ComfyUI_ControlNet_aux and ComfyUI_IPAdapter_plus using paths that are not relative to the ComfyUI root directory. This causes failed to load... errors in the console because Python cannot find the modules.

Solution: I've added the custom_nodes. prefix to the import statements in the following files to make the paths correct and allow the modules to be imported successfully.

Thank you!